### PR TITLE
Fix code scanning alert no. 25: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/yo.ts
+++ b/server/controllers/yo.ts
@@ -81,7 +81,7 @@ export const postYo = async (req: Request, res: Response, next: NextFunction): P
 
     if (validUrl.isUri(originalUrl)) {
         try {
-            const urlData = await Yo.findOne({ linkName });
+            const urlData = await Yo.findOne({ linkName: { $eq: linkName } });
 
             if (urlData) {
                 logger.info(`User ${ip} could not create a Yo as the name is already in-use: ${linkName}`);


### PR DESCRIPTION
Fixes [https://github.com/jonfairbanks/yo/security/code-scanning/25](https://github.com/jonfairbanks/yo/security/code-scanning/25)

To fix the problem, we need to ensure that the `linkName` parameter is sanitized before being used in the MongoDB query. The best way to do this is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This approach prevents NoSQL injection attacks by treating the user input as a simple value rather than part of the query structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
