### PR TITLE
Use GHCR for Docker images

### DIFF
--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "develop"
       - "main"
+  pull_request:
+    branches:
+      - "develop"
+      - "main"
 env:
   TERM: "xterm"
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -39,10 +43,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
 
@@ -53,6 +57,7 @@ jobs:
       - name: Lint Code
         run: npm run lint
         working-directory: src
+
   node-audit:
     name: Critical Vulnerability Check
     runs-on: ubuntu-latest
@@ -60,10 +65,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
 
@@ -85,7 +90,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Define sha_short
         id: vars
@@ -93,22 +98,15 @@ jobs:
 
       - name: Set up QEMU
         id: setup-qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: /tmp/.buildx-cache/${{ runner.os }}-${{ steps.setup-buildx.outputs.name }}-${{ hashFiles('**/Dockerfile') }}
-      #     key: ${{ runner.os }}-buildx-${{ steps.vars.outputs.sha_short }}-{{ hashFiles('**/Dockerfile') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,13 +114,13 @@ jobs:
 
       - name: Build & Push Docker image(s)
         id: docker-build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./src
           platforms: linux/amd64 # TODO: Re-add `linux/arm64`
           file: ./src/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           provenance: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/yo-url:${{ github.ref_name }}
@@ -134,4 +132,4 @@ jobs:
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
-        if: always()
+        if: always() && github.event_name == 'push'

--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -96,6 +96,16 @@ jobs:
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
+      - name: Compute safe Docker tag
+        id: image-tag
+        run: |
+          RAW_REF="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          SAFE_REF="$(echo "${RAW_REF}" | tr '/:@' '-' | tr -cd '[:alnum:]._-')"
+          if [ -z "${SAFE_REF}" ]; then
+            SAFE_REF="${GITHUB_SHA::12}"
+          fi
+          echo "value=${SAFE_REF}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up QEMU
         id: setup-qemu
         uses: docker/setup-qemu-action@v4
@@ -123,7 +133,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           provenance: false
           tags: |
-            ghcr.io/${{ github.repository_owner }}/yo-url:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/yo-url:${{ steps.image-tag.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         run: npm ci
@@ -65,7 +65,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -81,8 +81,8 @@ jobs:
     needs: [node-lint, node-audit]
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,36 +107,12 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-buildx-
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR
-        id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: "true"
-
-      - name: Get Repository Name
-        id: repo-name
-        run: echo "REPO_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-
-      - name: Create ECR Repository if not exists
-        env:
-          AWS_REGION: us-east-1
-          REPO_NAME: ${{ env.REPO_NAME }}
-        run: |
-          aws ecr describe-repositories --repository-names $REPO_NAME --region $AWS_REGION || \
-          aws ecr create-repository --repository-name $REPO_NAME --region $AWS_REGION
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Docker image(s)
         id: docker-build
@@ -149,8 +125,7 @@ jobs:
           push: true
           provenance: false
           tags: |
-            ${{ github.repository }}:develop
-            ${{ steps.ecr-login.outputs.registry }}/jonfairbanks/yo-api:develop
+            ghcr.io/${{ github.repository_owner }}/yo-url:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -82,7 +82,6 @@ jobs:
 
   docker-build:
     name: Docker Build
-    environment: development
     needs: [node-lint, node-audit]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-build-develop.yml
+++ b/.github/workflows/docker-build-develop.yml
@@ -106,6 +106,19 @@ jobs:
           fi
           echo "value=${SAFE_REF}" >> "${GITHUB_OUTPUT}"
 
+      - name: Compute Docker image tags
+        id: image-tags
+        run: |
+          TAGS="ghcr.io/${GITHUB_REPOSITORY_OWNER}/yo-url:${{ steps.image-tag.outputs.value }}"
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TAGS="${TAGS}"$'\n'"ghcr.io/${GITHUB_REPOSITORY_OWNER}/yo-url:latest"
+          fi
+          {
+            echo "value<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Set up QEMU
         id: setup-qemu
         uses: docker/setup-qemu-action@v4
@@ -132,8 +145,7 @@ jobs:
           file: ./src/Dockerfile
           push: ${{ github.event_name == 'push' }}
           provenance: false
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/yo-url:${{ steps.image-tag.outputs.value }}
+          tags: ${{ steps.image-tags.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/npm-lint.yml
+++ b/.github/workflows/npm-lint.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The application supports:
 
 ## Prerequisites
 
-- Node.js 22
+- Node.js 24
 - npm 10+
 - MongoDB
 - An Auth0 application for dashboard login

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,7 +16,7 @@ docker compose up
 
 Notes:
 
-- the compose file currently uses the published image `jonfairbanks/yo-api`
+- the compose file currently uses the published image `ghcr.io/jonfairbanks/yo-url:main`
 - the local `build:` block is commented out
 - if you want to build from this checkout instead of pulling the published image, uncomment the `build` section and remove or override `image`
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:22 AS deps
+FROM node:24 AS deps
 
 ENV TERM=xterm
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 
-FROM node:22 AS build
+FROM node:24 AS build
 
 ENV TERM=xterm
 WORKDIR /app
@@ -13,7 +13,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:22 AS production
+FROM node:24 AS production
 
 ENV NODE_ENV=production
 ENV TERM=xterm

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # build:
     #   context: .
     #   dockerfile: src/Dockerfile
-    image: jonfairbanks/yo-api
+    image: ghcr.io/jonfairbanks/yo-url:main
     ports:
       - "3000:3000"
     env_file:

--- a/src/package.json
+++ b/src/package.json
@@ -2,6 +2,9 @@
   "name": "yo-url",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",


### PR DESCRIPTION
This pull request updates the Docker build workflow configuration to switch from publishing Docker images to DockerHub and Amazon ECR, to publishing exclusively to GitHub Container Registry (GHCR). It also updates the permissions and image tagging strategy to align with this change.

Container registry migration:

* Replaced DockerHub and Amazon ECR login steps with a login to GitHub Container Registry using the `docker/login-action` and GitHub credentials. Removed all AWS credential configuration and ECR repository setup steps.
* Updated the Docker image tag to use the GHCR format (`ghcr.io/${{ github.repository_owner }}/yo-url:${{ github.ref_name }}`) instead of DockerHub or ECR tags.

Workflow permissions:

* Changed workflow permissions to remove `actions: write` and add `packages: write` to allow pushing images to GHCR.