### PR TITLE
Restrict Dependabot auto-merge to non-major updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge
+      - id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Restrict the privileged Dependabot merge-control workflow to verified patch and minor updates.

## Why

Major update PR #298 (OpenTelemetry 1 to 2) was incorrectly armed for auto-merge despite failing checks. Major updates require a deliberate migration.

## Changes

- fetch Dependabot metadata using the SHA-pinned official action
- enable squash auto-merge only for patch or minor updates
- retain exact same-repository Dependabot identity checks and no checkout of PR code

## Validation

- YAML syntax validation
- diff check
- verified #298 has auto-merge disabled